### PR TITLE
Lightweight layout on asynchronous loading

### DIFF
--- a/src/Screen/Layout.php
+++ b/src/Screen/Layout.php
@@ -101,28 +101,30 @@ abstract class Layout implements JsonSerializable
     {
         $this->query = $repository;
 
-        if (! $this->isSee()) {
+        if (!$this->isSee()) {
             return;
         }
 
-        $build = collect($this->layouts)
-            ->map(function ($layouts) {
-                return Arr::wrap($layouts);
-            })
-            ->map(function (iterable $layouts, string $key) use ($repository) {
-                return $this->buildChild($layouts, $key, $repository);
-            })
-            ->collapse()
-            ->all();
+        if (!$this->asyncMethod || ($this->asyncMethod && $this->async)) {
+            $build = collect($this->layouts)
+                ->map(function ($layouts) {
+                    return Arr::wrap($layouts);
+                })
+                ->map(function (array $layouts, string $key) use ($repository) {
+                    return $this->buildChild($layouts, $key, $repository);
+                })
+                ->collapse()
+                ->all();
+        }
 
         $variables = array_merge($this->variables, [
-            'manyForms'    => $build,
+            'manyForms'    => isset($build) ? $build : [],
             'templateSlug' => $this->getSlug(),
             'asyncEnable'  => empty($this->asyncMethod) ? 0 : 1,
             'asyncRoute'   => $this->asyncRoute(),
         ]);
 
-        return view($this->async ? 'platform::layouts.blank' : $this->template, $variables);
+        return view($this->async ? 'layouts.blank' : $this->template, $variables);
     }
 
     /**

--- a/src/Screen/Layout.php
+++ b/src/Screen/Layout.php
@@ -92,7 +92,7 @@ abstract class Layout implements JsonSerializable
         return $this;
     }
 
-    /**
+        /**
      * @param Repository $repository
      *
      * @return mixed
@@ -105,26 +105,34 @@ abstract class Layout implements JsonSerializable
             return;
         }
 
-        if (!$this->asyncMethod || ($this->asyncMethod && $this->async)) {
-            $build = collect($this->layouts)
-                ->map(function ($layouts) {
-                    return Arr::wrap($layouts);
-                })
-                ->map(function (array $layouts, string $key) use ($repository) {
-                    return $this->buildChild($layouts, $key, $repository);
-                })
-                ->collapse()
-                ->all();
-        }
-
         $variables = array_merge($this->variables, [
-            'manyForms'    => isset($build) ? $build : [],
+            'manyForms'    => $this->reparation(),
             'templateSlug' => $this->getSlug(),
             'asyncEnable'  => empty($this->asyncMethod) ? 0 : 1,
             'asyncRoute'   => $this->asyncRoute(),
         ]);
 
-        return view($this->async ? 'platform::layouts.blank' : $this->template, $variables);
+        return view($this->async ? 'layouts.blank' : $this->template, $variables);
+    }
+
+    /**
+     * @return array
+     */
+    protected function reparation(): array
+    {
+        if ($this->asyncMethod && !$this->async) {
+            return [];
+        }
+
+        return collect($this->layouts)
+            ->map(function ($layouts) {
+                return Arr::wrap($layouts);
+            })
+            ->map(function (array $layouts, string $key) {
+                return $this->buildChild($layouts, $key, $this->query);
+            })
+            ->collapse()
+            ->all();
     }
 
     /**

--- a/src/Screen/Layout.php
+++ b/src/Screen/Layout.php
@@ -112,7 +112,7 @@ abstract class Layout implements JsonSerializable
             'asyncRoute'   => $this->asyncRoute(),
         ]);
 
-        return view($this->async ? 'layouts.blank' : $this->template, $variables);
+        return view($this->async ? 'platform::layouts.blank' : $this->template, $variables);
     }
 
     /**

--- a/src/Screen/Layout.php
+++ b/src/Screen/Layout.php
@@ -124,7 +124,7 @@ abstract class Layout implements JsonSerializable
             'asyncRoute'   => $this->asyncRoute(),
         ]);
 
-        return view($this->async ? 'layouts.blank' : $this->template, $variables);
+        return view($this->async ? 'platform::layouts.blank' : $this->template, $variables);
     }
 
     /**


### PR DESCRIPTION
Hello, this corrects the following points:

- Speeds up screen loading by not rendering empty layouts, which are subsequently replaced by an async request.

- We no longer need to predefine properties in the `query()` method that are equal to those that we would use in asynchronously loaded layouts.

> Previously, for example, this was necessary if we used the `canSee()` method, like so:
> 
> `->canSee($this->query->get('user')->exists)`.

> Example:
> 
> We have an asynchronous modal window to which we pass the user model through the asyncGetUser() method, in this modal window there is a layout with a form in which, depending on whether the user exists or not, we want to hide one of the fields through a function `->canSee($this->query->get('user')->exists)`.
> 
> We'll get an error because when the screen first loads, `$this->query->get('user')` will be null,
> Therefore, as one of the options, we needed to predefine it in the `query()` method, thus:
> 
> ```
> public function query(User $user)
> {
>        return [
>               'user' => $user
>        ];
> }
> ```
> 

In my particular case, when I use a lot of async modals, this gave me some pluses, in terms of memory, the number of layouts loaded and speed.
<img width="1680" alt="Снимок экрана 2022-02-09 в 00 16 06" src="https://user-images.githubusercontent.com/59070939/153087943-8a76ab40-d5e9-4a11-8dcf-7b95457722e5.png">
<img width="1680" alt="Снимок экрана 2022-02-09 в 00 18 25" src="https://user-images.githubusercontent.com/59070939/153087953-96917784-3cad-4084-af51-8fcabdcd3344.png">
